### PR TITLE
Complete Playwright visual source: add optional dependency and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ https://jmjava.github.io/documentation-generator/
 - **TTS narration** — generate MP3 audio from Markdown scripts via OpenAI gpt-4o-mini-tts
 - **Manim animations** — render programmatic animation scenes
 - **VHS terminal recordings** — render `.tape` files into MP4s
+- **Playwright browser capture** — record browser-based demos as MP4 via headless Chromium
 - **ffmpeg composition** — combine audio + video into final segments
 - **Validation** — OCR error detection, layout analysis, audio-visual sync, narration linting
 - **GitHub Pages** — auto-generate `index.html`, deploy workflow, LFS rules, `.gitignore`
@@ -132,6 +133,7 @@ Script contract:
   `DOCGEN_PLAYWRIGHT_WIDTH`, `DOCGEN_PLAYWRIGHT_HEIGHT`, and optional segment metadata
 - must write an MP4 to the requested output path
 - should use headless Playwright for CI compatibility
+
 ### VHS safety: avoid real long-running commands in tapes
 
 VHS executes commands in a real shell session. For demos, prefer simulated output with `echo`
@@ -175,6 +177,7 @@ docgen generate-all --retry-manim
 - **tesseract-ocr** — OCR validation
 - **VHS** — terminal recording (charmbracelet/vhs)
 - **Manim** — animation rendering (optional, install with `pip install docgen[manim]`)
+- **Playwright** — browser capture (optional, install with `pip install docgen[playwright]` then `playwright install chromium`)
 
 ## Milestone spec
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 
 [project.optional-dependencies]
 manim = ["manim>=0.18"]
+playwright = ["playwright>=1.40"]
 dev = [
     "pytest>=7.0",
     "pytest-cov",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #16 requested adding `type: playwright` as a visual source for browser-based capture. The implementation is already complete across the codebase. This PR closes the remaining gaps: an explicit optional dependency and complete documentation.

### What was already implemented

- `PlaywrightRunner` class in `playwright_runner.py` - runs external capture scripts
- `docgen playwright` CLI command for standalone capture
- `type: playwright` dispatch in `compose.py` for pipeline integration  
- Configuration block (`playwright:`) in `docgen.yaml` schema
- README section documenting `type: playwright` visual map entries and script contract
- Test coverage in `test_playwright_runner.py` and `test_compose.py`

### What this PR adds

- **`playwright` optional dependency** in `pyproject.toml` (`pip install docgen[playwright]`)
- **Features section** in README now lists Playwright browser capture
- **System dependencies** section now includes Playwright with install instructions
- **Formatting fix**: missing blank line before VHS safety section

### Acceptance criteria from issue #16

| Criteria | Status |
|----------|--------|
| `docgen playwright --script my_script.py --url http://localhost:3300` produces an MP4 | Done (CLI + runner) |
| `type: playwright` segments compose correctly with narration audio | Done (compose.py) |
| Headless mode works on Ubuntu (CI-compatible) | Done (uses headless Chromium) |
| Documentation updated with Playwright visual source examples | Done (README) |

Closes #16
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-140d55bb-bebf-4e6f-bf13-48af728f96fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-140d55bb-bebf-4e6f-bf13-48af728f96fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

