### PR TITLE
Add docgen scene-gen: auto-generate Manim scenes from narration markdown

### DIFF
--- a/src/docgen/cli.py
+++ b/src/docgen/cli.py
@@ -310,6 +310,28 @@ def pages(ctx: click.Context, force: bool) -> None:
     gen.generate_all(force=force)
 
 
+@main.command("scene-gen")
+@click.option("--segment", default=None, help="Generate scene for a single segment.")
+@click.option("--force", is_flag=True, help="Overwrite existing scene files.")
+@click.option("--dry-run", is_flag=True, help="Print generated code without writing files.")
+@click.pass_context
+def scene_gen(ctx: click.Context, segment: str | None, force: bool, dry_run: bool) -> None:
+    """Auto-generate Manim scenes from narration markdown.
+
+    Parses narration structure (headings, bullets, text) and generates
+    Manim scene code with proper timing. Manual scenes can be kept as
+    opt-in overrides.
+    """
+    from docgen.scene_gen import SceneGenerator
+
+    cfg = ctx.obj["config"]
+    gen = SceneGenerator(cfg)
+    created = gen.generate(segment=segment, force=force, dry_run=dry_run)
+    if created and not dry_run:
+        click.echo(f"\nGenerated {len(created)} scene file(s).")
+        click.echo("Next: docgen manim && docgen compose")
+
+
 @main.command("generate-all")
 @click.option("--skip-tts", is_flag=True)
 @click.option("--skip-manim", is_flag=True)

--- a/src/docgen/scene_gen.py
+++ b/src/docgen/scene_gen.py
@@ -1,0 +1,347 @@
+"""Auto-generate Manim scenes from narration markdown and timing data.
+
+Implements Option A from issue #1: parse narration structure (headings,
+bullets, bold text, paragraph breaks) and combine with timing data to
+produce a renderable scenes.py.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from docgen.config import Config
+
+
+@dataclass
+class VisualBeat:
+    """A single visual element extracted from narration."""
+
+    kind: str  # title, bullets, text, transition
+    text: str = ""
+    items: list[str] = field(default_factory=list)
+    at_sec: float = 0.0
+    duration_sec: float = 5.0
+
+
+@dataclass
+class SegmentScene:
+    """Collected visual beats for one segment."""
+
+    segment_id: str
+    scene_name: str
+    beats: list[VisualBeat] = field(default_factory=list)
+    total_duration_sec: float = 60.0
+    font: str = "Liberation Sans"
+
+
+def parse_narration(text: str) -> list[VisualBeat]:
+    """Extract visual beats from narration markdown.
+
+    Recognises:
+    - ``# heading`` → title beat
+    - ``- item`` / ``* item`` / ``1. item`` → bullets beat
+    - Bold/code spans → highlighted text
+    - Paragraph breaks → transition
+    """
+    beats: list[VisualBeat] = []
+    lines = text.splitlines()
+    i = 0
+
+    while i < len(lines):
+        line = lines[i].strip()
+
+        if not line:
+            i += 1
+            continue
+
+        if re.match(r"^(target duration|intended length|visual:|edit for voice)", line, re.I):
+            i += 1
+            continue
+
+        if re.match(r"^\*?\(.*\)\*?$", line):
+            i += 1
+            continue
+
+        if re.match(r"^[-*_]{3,}$", line):
+            beats.append(VisualBeat(kind="transition"))
+            i += 1
+            continue
+
+        heading_match = re.match(r"^(#{1,3})\s+(.+)$", line)
+        if heading_match:
+            title = heading_match.group(2).strip()
+            title = _strip_md_inline(title)
+            beats.append(VisualBeat(kind="title", text=title))
+            i += 1
+            continue
+
+        if re.match(r"^[-*]\s+", line) or re.match(r"^\d+\.\s+", line):
+            items: list[str] = []
+            while i < len(lines):
+                bline = lines[i].strip()
+                bullet_match = re.match(r"^(?:[-*]|\d+\.)\s+(.+)$", bline)
+                if bullet_match:
+                    items.append(_strip_md_inline(bullet_match.group(1)))
+                    i += 1
+                elif not bline:
+                    break
+                else:
+                    break
+            beats.append(VisualBeat(kind="bullets", items=items))
+            continue
+
+        text_content = _strip_md_inline(line)
+        if text_content:
+            beats.append(VisualBeat(kind="text", text=text_content))
+        i += 1
+
+    return beats
+
+
+def _strip_md_inline(text: str) -> str:
+    """Remove bold/italic markers, inline code, and links."""
+    text = re.sub(r"\*{1,3}(.+?)\*{1,3}", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    return text.strip()
+
+
+def assign_timing(beats: list[VisualBeat], total_duration: float) -> None:
+    """Distribute timing across beats evenly, with buffer between sections."""
+    displayable = [b for b in beats if b.kind != "transition"]
+    if not displayable:
+        return
+
+    buffer_sec = 1.0
+    available = total_duration - buffer_sec * len(displayable)
+    per_beat = max(3.0, available / len(displayable)) if displayable else 5.0
+
+    t = 0.0
+    beat_idx = 0
+    for beat in beats:
+        if beat.kind == "transition":
+            t += 1.0
+            continue
+        beat.at_sec = t
+        beat.duration_sec = per_beat
+        t += per_beat + buffer_sec
+        beat_idx += 1
+
+
+def load_timing(config: Config, seg_id: str) -> float | None:
+    """Read total audio duration from timing.json if it exists."""
+    timing_path = config.animations_dir / "timing.json"
+    if not timing_path.exists():
+        return None
+    try:
+        data = json.loads(timing_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    seg_name = config.resolve_segment_name(seg_id)
+    for key in (seg_name, seg_id):
+        entry = data.get(key, {})
+        if "duration" in entry:
+            return float(entry["duration"])
+        segments = entry.get("segments", [])
+        if segments:
+            last = segments[-1]
+            return float(last.get("end", 0))
+    return None
+
+
+def generate_scene_code(scene: SegmentScene) -> str:
+    """Generate Manim Python source for a single segment scene."""
+    font = scene.font.replace('"', '\\"')
+    lines = [
+        f'"""Auto-generated Manim scene for segment {scene.segment_id}.',
+        "",
+        "Generated by `docgen scene-gen`. Edit freely — manual changes are preserved",
+        "unless you re-run `docgen scene-gen --force`.",
+        '"""',
+        "",
+        "from manim import *",
+        "",
+        "",
+        f"class {scene.scene_name}(Scene):",
+        "    def construct(self):",
+        f'        Text.set_default(font="{font}")',
+        "        self.camera.background_color = \"#1e1e2e\"",
+        "",
+    ]
+
+    if not scene.beats:
+        lines.append("        self.wait(2)")
+        return "\n".join(lines) + "\n"
+
+    for beat in scene.beats:
+        if beat.kind == "title":
+            safe_text = _safe_string(beat.text)
+            lines.extend([
+                f"        # Title at {beat.at_sec:.1f}s",
+                f"        title = Text({safe_text}, font_size=36, color=WHITE)",
+                "        title.to_edge(UP, buff=1.0)",
+                "        self.play(FadeIn(title), run_time=0.8)",
+                f"        self.wait({max(1.0, beat.duration_sec - 1.5):.1f})",
+                "        self.play(FadeOut(title), run_time=0.5)",
+                "",
+            ])
+        elif beat.kind == "bullets":
+            lines.append(f"        # Bullets at {beat.at_sec:.1f}s")
+            lines.append("        bullet_group = VGroup()")
+            for item in beat.items:
+                safe_item = _safe_string(item)
+                lines.append(
+                    f"        bullet_group.add(Text({safe_item}, font_size=18, color=WHITE))"
+                )
+            lines.extend([
+                "        bullet_group.arrange(DOWN, buff=0.25, aligned_edge=LEFT)",
+                "        bullet_group.center()",
+                "        for mob in bullet_group:",
+                "            self.play(FadeIn(mob, shift=RIGHT * 0.3), run_time=0.4)",
+                f"        self.wait({max(1.0, beat.duration_sec - len(beat.items) * 0.5 - 0.5):.1f})",
+                "        self.play(FadeOut(bullet_group), run_time=0.5)",
+                "",
+            ])
+        elif beat.kind == "text":
+            safe_text = _safe_string(beat.text)
+            lines.extend([
+                f"        # Text at {beat.at_sec:.1f}s",
+                f"        body = Text({safe_text}, font_size=20, color=WHITE)",
+                "        body.center()",
+                "        self.play(FadeIn(body), run_time=0.6)",
+                f"        self.wait({max(1.0, beat.duration_sec - 1.3):.1f})",
+                "        self.play(FadeOut(body), run_time=0.5)",
+                "",
+            ])
+        elif beat.kind == "transition":
+            lines.append("        self.wait(1.0)")
+            lines.append("")
+
+    remaining = max(0, scene.total_duration_sec - (
+        sum(b.duration_sec + 1.0 for b in scene.beats if b.kind != "transition")
+    ))
+    if remaining > 0.5:
+        lines.append(f"        self.wait({remaining:.1f})")
+
+    return "\n".join(lines) + "\n"
+
+
+def _safe_string(text: str) -> str:
+    """Return a Python string literal safe for embedding in generated code."""
+    _UNSAFE_MAP = {
+        "\u2192": "->", "\u2190": "<-", "\u2194": "<->",
+        "\u203a": ">", "\u2039": "<",
+        "\u2260": "!=", "\u2264": "<=", "\u2265": ">=",
+        "\u2014": "--", "\u2013": "-",
+        "\u2018": "'", "\u2019": "'",
+        "\u201c": '"', "\u201d": '"',
+        "\u2022": "-", "\u2026": "...",
+    }
+    for ch, repl in _UNSAFE_MAP.items():
+        text = text.replace(ch, repl)
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+class SceneGenerator:
+    """Generates Manim scenes from narration markdown files."""
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    def generate(
+        self,
+        segment: str | None = None,
+        *,
+        force: bool = False,
+        dry_run: bool = False,
+    ) -> list[str]:
+        """Generate scene files. Returns list of created/updated file paths."""
+        segments = [segment] if segment else self.config.segments_all
+        created: list[str] = []
+
+        for seg_id in segments:
+            vmap = self.config.visual_map.get(seg_id, {})
+            if vmap.get("type", "manim") != "manim":
+                print(f"[scene-gen] {seg_id}: type={vmap.get('type')} — skipping (not manim)")
+                continue
+
+            result = self._generate_one(seg_id, vmap, force=force, dry_run=dry_run)
+            if result:
+                created.append(result)
+
+        return created
+
+    def _generate_one(
+        self,
+        seg_id: str,
+        vmap: dict,
+        *,
+        force: bool = False,
+        dry_run: bool = False,
+    ) -> str | None:
+        narration = self._find_narration(seg_id)
+        if not narration:
+            print(f"[scene-gen] {seg_id}: no narration file found")
+            return None
+
+        text = narration.read_text(encoding="utf-8")
+        beats = parse_narration(text)
+        if not beats:
+            print(f"[scene-gen] {seg_id}: no visual beats extracted from narration")
+            return None
+
+        scene_name = vmap.get("scene", f"Scene{seg_id}")
+        total_duration = load_timing(self.config, seg_id) or 60.0
+
+        assign_timing(beats, total_duration)
+
+        scene = SegmentScene(
+            segment_id=seg_id,
+            scene_name=scene_name,
+            beats=beats,
+            total_duration_sec=total_duration,
+            font=self.config.manim_font,
+        )
+
+        code = generate_scene_code(scene)
+
+        if dry_run:
+            print(f"[scene-gen] {seg_id}: {scene_name} ({len(beats)} beats, {total_duration:.1f}s)")
+            print(code)
+            return None
+
+        output_dir = self.config.animations_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_file = output_dir / f"scene_{seg_id}.py"
+
+        if output_file.exists() and not force:
+            print(
+                f"[scene-gen] {seg_id}: {output_file} already exists. "
+                "Use --force to overwrite."
+            )
+            return None
+
+        output_file.write_text(code, encoding="utf-8")
+        print(f"[scene-gen] {seg_id}: wrote {output_file} ({len(beats)} beats, {total_duration:.1f}s)")
+        return str(output_file)
+
+    def _find_narration(self, seg_id: str) -> Path | None:
+        d = self.config.narration_dir
+        if not d.exists():
+            return None
+        seg_name = self.config.resolve_segment_name(seg_id)
+        exact = d / f"{seg_name}.md"
+        if exact.exists():
+            return exact
+        for md in d.glob(f"{seg_id}-*.md"):
+            return md
+        for md in d.glob(f"*{seg_id}*.md"):
+            return md
+        return None

--- a/tests/test_scene_gen.py
+++ b/tests/test_scene_gen.py
@@ -1,0 +1,326 @@
+"""Tests for docgen.scene_gen — auto-generated Manim scenes from narration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from docgen.config import Config
+from docgen.scene_gen import (
+    SceneGenerator,
+    SegmentScene,
+    VisualBeat,
+    assign_timing,
+    generate_scene_code,
+    load_timing,
+    parse_narration,
+)
+
+
+# ── parse_narration ───────────────────────────────────────────────────
+
+
+class TestParseNarration:
+    def test_extracts_headings(self):
+        beats = parse_narration("# Welcome\nSome text.\n## Details\n")
+        titles = [b for b in beats if b.kind == "title"]
+        assert len(titles) == 2
+        assert titles[0].text == "Welcome"
+        assert titles[1].text == "Details"
+
+    def test_extracts_bullets(self):
+        text = "- First item\n- Second item\n- Third item\n"
+        beats = parse_narration(text)
+        bullet_beats = [b for b in beats if b.kind == "bullets"]
+        assert len(bullet_beats) == 1
+        assert bullet_beats[0].items == ["First item", "Second item", "Third item"]
+
+    def test_extracts_numbered_list(self):
+        text = "1. Alpha\n2. Beta\n3. Gamma\n"
+        beats = parse_narration(text)
+        bullet_beats = [b for b in beats if b.kind == "bullets"]
+        assert len(bullet_beats) == 1
+        assert bullet_beats[0].items == ["Alpha", "Beta", "Gamma"]
+
+    def test_extracts_plain_text(self):
+        text = "This is a spoken paragraph about Tekton pipelines."
+        beats = parse_narration(text)
+        assert len(beats) == 1
+        assert beats[0].kind == "text"
+        assert "Tekton" in beats[0].text
+
+    def test_strips_markdown_inline(self):
+        text = "This is **bold** and `code` and [link](http://x.com)."
+        beats = parse_narration(text)
+        assert beats[0].text == "This is bold and code and link."
+
+    def test_horizontal_rule_becomes_transition(self):
+        text = "Before\n---\nAfter"
+        beats = parse_narration(text)
+        kinds = [b.kind for b in beats]
+        assert "transition" in kinds
+
+    def test_skips_metadata_lines(self):
+        text = "target duration: 2 minutes\n# Real Heading\n"
+        beats = parse_narration(text)
+        assert len(beats) == 1
+        assert beats[0].kind == "title"
+
+    def test_skips_stage_directions(self):
+        text = "*(pause)*\n# Title\n"
+        beats = parse_narration(text)
+        assert len(beats) == 1
+        assert beats[0].kind == "title"
+
+    def test_empty_input(self):
+        assert parse_narration("") == []
+        assert parse_narration("\n\n\n") == []
+
+    def test_mixed_content(self):
+        text = "# Intro\nSome narration.\n- Point A\n- Point B\n---\n# Conclusion\n"
+        beats = parse_narration(text)
+        kinds = [b.kind for b in beats]
+        assert kinds == ["title", "text", "bullets", "transition", "title"]
+
+
+# ── assign_timing ─────────────────────────────────────────────────────
+
+
+class TestAssignTiming:
+    def test_distributes_time_evenly(self):
+        beats = [
+            VisualBeat(kind="title", text="A"),
+            VisualBeat(kind="text", text="B"),
+        ]
+        assign_timing(beats, 20.0)
+        assert beats[0].at_sec == 0.0
+        assert beats[1].at_sec > beats[0].at_sec
+
+    def test_skips_transitions(self):
+        beats = [
+            VisualBeat(kind="title", text="A"),
+            VisualBeat(kind="transition"),
+            VisualBeat(kind="text", text="B"),
+        ]
+        assign_timing(beats, 20.0)
+        assert beats[1].kind == "transition"
+        assert beats[2].at_sec > beats[0].at_sec
+
+    def test_empty_beats(self):
+        beats: list[VisualBeat] = []
+        assign_timing(beats, 10.0)
+
+    def test_minimum_duration(self):
+        beats = [VisualBeat(kind="text", text=f"Item {i}") for i in range(20)]
+        assign_timing(beats, 30.0)
+        for b in beats:
+            assert b.duration_sec >= 3.0
+
+
+# ── generate_scene_code ───────────────────────────────────────────────
+
+
+class TestGenerateSceneCode:
+    def test_generates_valid_python(self):
+        scene = SegmentScene(
+            segment_id="01",
+            scene_name="Scene01",
+            beats=[VisualBeat(kind="title", text="Hello World", at_sec=0.0, duration_sec=5.0)],
+            total_duration_sec=10.0,
+            font="Liberation Sans",
+        )
+        code = generate_scene_code(scene)
+        assert "class Scene01(Scene):" in code
+        assert "from manim import *" in code
+        assert "Liberation Sans" in code
+        assert "Hello World" in code
+        compile(code, "<test>", "exec")
+
+    def test_generates_bullet_scene(self):
+        scene = SegmentScene(
+            segment_id="02",
+            scene_name="Scene02",
+            beats=[VisualBeat(
+                kind="bullets",
+                items=["First", "Second", "Third"],
+                at_sec=0.0,
+                duration_sec=8.0,
+            )],
+            total_duration_sec=10.0,
+        )
+        code = generate_scene_code(scene)
+        assert "bullet_group" in code
+        assert "First" in code
+        assert "arrange(DOWN" in code
+        compile(code, "<test>", "exec")
+
+    def test_empty_beats_generates_wait(self):
+        scene = SegmentScene(segment_id="03", scene_name="Scene03", beats=[])
+        code = generate_scene_code(scene)
+        assert "self.wait(2)" in code
+        compile(code, "<test>", "exec")
+
+    def test_escapes_quotes(self):
+        scene = SegmentScene(
+            segment_id="04",
+            scene_name="Scene04",
+            beats=[VisualBeat(kind="text", text='He said "hello"', at_sec=0.0, duration_sec=5.0)],
+        )
+        code = generate_scene_code(scene)
+        compile(code, "<test>", "exec")
+
+    def test_replaces_unsafe_unicode(self):
+        scene = SegmentScene(
+            segment_id="05",
+            scene_name="Scene05",
+            beats=[VisualBeat(kind="text", text="arrow \u2192 here", at_sec=0.0, duration_sec=5.0)],
+        )
+        code = generate_scene_code(scene)
+        assert "\u2192" not in code
+        assert "->" in code
+
+    def test_uses_relative_layout(self):
+        """Generated code should use arrange/center, not absolute coordinates."""
+        scene = SegmentScene(
+            segment_id="06",
+            scene_name="Scene06",
+            beats=[
+                VisualBeat(kind="title", text="Title", at_sec=0.0, duration_sec=3.0),
+                VisualBeat(kind="bullets", items=["A", "B"], at_sec=4.0, duration_sec=5.0),
+            ],
+        )
+        code = generate_scene_code(scene)
+        assert "to_edge" in code or "center" in code
+        assert "arrange(DOWN" in code
+        assert "move_to" not in code
+
+    def test_never_uses_bold(self):
+        """Generated scenes must not use weight=BOLD."""
+        scene = SegmentScene(
+            segment_id="07",
+            scene_name="Scene07",
+            beats=[
+                VisualBeat(kind="title", text="Title", at_sec=0.0, duration_sec=3.0),
+                VisualBeat(kind="bullets", items=["A", "B"], at_sec=4.0, duration_sec=5.0),
+                VisualBeat(kind="text", text="Body", at_sec=10.0, duration_sec=3.0),
+            ],
+        )
+        code = generate_scene_code(scene)
+        assert "BOLD" not in code
+        assert "weight" not in code
+
+
+# ── load_timing ──────────────────────────────────────────────────────
+
+
+class TestLoadTiming:
+    def test_loads_duration_from_timing_json(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        timing = {"01-overview": {"duration": 95.5, "segments": []}}
+        (tmp_path / "animations" / "timing.json").write_text(
+            json.dumps(timing), encoding="utf-8"
+        )
+        result = load_timing(cfg, "01")
+        assert result == 95.5
+
+    def test_returns_none_when_missing(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        assert load_timing(cfg, "01") is None
+
+    def test_uses_segment_end_as_fallback(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        timing = {
+            "01-overview": {
+                "segments": [
+                    {"start": 0.0, "end": 45.0, "text": "..."},
+                    {"start": 45.0, "end": 90.0, "text": "..."},
+                ]
+            }
+        }
+        (tmp_path / "animations" / "timing.json").write_text(
+            json.dumps(timing), encoding="utf-8"
+        )
+        result = load_timing(cfg, "01")
+        assert result == 90.0
+
+
+# ── SceneGenerator integration ────────────────────────────────────────
+
+
+class TestSceneGenerator:
+    def test_generates_scene_file(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        narr = tmp_path / "narration" / "01-overview.md"
+        narr.write_text("# Welcome\nThis is the overview.\n- Feature A\n- Feature B\n")
+        gen = SceneGenerator(cfg)
+        created = gen.generate()
+        assert len(created) == 1
+        scene_file = Path(created[0])
+        assert scene_file.exists()
+        code = scene_file.read_text()
+        assert "class DocgenOverviewScene(Scene):" in code
+        compile(code, "<test>", "exec")
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        narr = tmp_path / "narration" / "01-overview.md"
+        narr.write_text("# Hello\nWorld\n")
+        gen = SceneGenerator(cfg)
+        created = gen.generate(dry_run=True)
+        assert created == []
+        assert not (tmp_path / "animations" / "scene_01.py").exists()
+
+    def test_skips_existing_without_force(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        narr = tmp_path / "narration" / "01-overview.md"
+        narr.write_text("# Hello\nWorld\n")
+        scene = tmp_path / "animations" / "scene_01.py"
+        scene.write_text("existing content")
+        gen = SceneGenerator(cfg)
+        created = gen.generate()
+        assert created == []
+        assert scene.read_text() == "existing content"
+
+    def test_force_overwrites(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        narr = tmp_path / "narration" / "01-overview.md"
+        narr.write_text("# Hello\nWorld\n")
+        scene = tmp_path / "animations" / "scene_01.py"
+        scene.write_text("existing content")
+        gen = SceneGenerator(cfg)
+        created = gen.generate(force=True)
+        assert len(created) == 1
+        assert "existing content" not in scene.read_text()
+
+    def test_skips_non_manim_segments(self, tmp_path):
+        cfg_data = {
+            "segments": {"default": ["01"], "all": ["01"]},
+            "segment_names": {"01": "01-overview"},
+            "visual_map": {"01": {"type": "vhs", "source": "01.mp4"}},
+        }
+        (tmp_path / "docgen.yaml").write_text(yaml.dump(cfg_data), encoding="utf-8")
+        for d in ("narration", "audio", "animations", "terminal", "recordings"):
+            (tmp_path / d).mkdir(exist_ok=True)
+        (tmp_path / "narration" / "01-overview.md").write_text("# Hello\n")
+        cfg = Config.from_yaml(tmp_path / "docgen.yaml")
+        gen = SceneGenerator(cfg)
+        created = gen.generate()
+        assert created == []
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _make_config(tmp_path: Path) -> Config:
+    cfg = {
+        "segments": {"default": ["01"], "all": ["01"]},
+        "segment_names": {"01": "01-overview"},
+        "visual_map": {"01": {"type": "manim", "scene": "DocgenOverviewScene", "source": "DocgenOverviewScene.mp4"}},
+        "manim": {"font": "Liberation Sans"},
+    }
+    (tmp_path / "docgen.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+    for d in ("narration", "audio", "animations", "terminal", "recordings"):
+        (tmp_path / d).mkdir(exist_ok=True)
+    return Config.from_yaml(tmp_path / "docgen.yaml")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses the core design flaw described in issue #1: Manim scene authoring was a fully manual gap in the pipeline. Now `docgen scene-gen` can automatically generate renderable Manim scenes from narration markdown, eliminating the `???` step.

### Problem

The pipeline was: `narration → tts → timestamps → ??? → manim → compose`

The `???` required manually writing Python Manim scene classes, reading timing.json to place animations at the right timestamps. This was undocumented, time-consuming (~30+ min per segment), and fragile when TTS durations changed.

### Solution: `docgen scene-gen`

New CLI command that parses narration markdown and generates Manim scene code:

```bash
docgen scene-gen                     # generate all segments
docgen scene-gen --segment 01        # single segment
docgen scene-gen --dry-run           # preview without writing
docgen scene-gen --force             # overwrite existing scenes
```

The pipeline now becomes: `narration → tts → timestamps → scene-gen → manim → compose`

### How it works

**Narration parsing** extracts visual beats from markdown structure:
- `# Heading` → title card (font_size=36, FadeIn/FadeOut)
- `- Item` / `1. Item` → bullet list (VGroup.arrange, sequential reveals)
- Plain paragraphs → centered body text (font_size=20)
- `---` horizontal rules → visual transitions

**Timing integration** reads `animations/timing.json` (from `docgen timestamps`) to distribute beats evenly across the audio duration with buffer between sections.

**Generated code** follows all lessons from issue #3:
- `Text.set_default(font="Liberation Sans")` before any Text()
- Uses `arrange(DOWN)`, `center()`, `to_edge()` — never absolute coordinates
- Never uses `weight=BOLD` (Pango font substitution prevention)
- Replaces unsafe unicode (→, ›, —, etc.) with ASCII equivalents
- Minimum font sizes: title=36, bullets=18, body=20
- Dark background (`#1e1e2e`) with WHITE text

**Manual scenes remain supported**: generated files are per-segment (`scene_01.py`) and won't overwrite existing files without `--force`.

### New files

| File | Purpose |
|------|---------|
| `src/docgen/scene_gen.py` | Scene generator module: parsing, timing, code generation |
| `tests/test_scene_gen.py` | 29 tests covering all components |

### Changes to existing files

| File | Change |
|------|--------|
| `src/docgen/cli.py` | Added `scene-gen` command |
| `src/docgen/config.py` | Added `manim_font` property |

### Acceptance criteria from issue #1

| Criteria | Status |
|----------|--------|
| `docgen init` scaffolds projects that produce watchable videos without hand-written Manim | Addressed — `scene-gen` generates renderable scenes from narration |
| Regenerating TTS (longer/shorter audio) automatically adjusts visuals | Addressed — `scene-gen` reads timing.json; re-running after `timestamps` updates timing |
| Manual Manim scenes remain supported as an upgrade path | Done — per-segment files, no overwrite without `--force` |
| Documentation clearly states the visual authoring workflow | Done — CLI help, docstrings, generated file headers |

### Testing

- 125 total tests pass (`pytest tests/ --ignore=tests/e2e`)
- 29 new tests for scene_gen module
- `ruff check src/ tests/` — all checks passed

Closes #1
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-140d55bb-bebf-4e6f-bf13-48af728f96fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-140d55bb-bebf-4e6f-bf13-48af728f96fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

