### PR TITLE
feat(wizard): asset freshness, rebuild-from-here, in-place narration revise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ The Playwright/VHS/demo-function/per-function/discover-tests/catalog surface are
 Commands registered on the **`docgen`** CLI include:
 
 - **`init`** — scaffold bundle layout and `docgen.yaml`.
-- **`wizard`** — local web UI for narration/bootstrap workflows.
+- **`wizard`** — local web UI for narration/bootstrap workflows (focus files, **in-place narration revise**, per-segment **asset freshness** + **rebuild-from-here**).
 - **`tts`** — text-to-speech for segment files.
 - **`timestamps`** — word/segment timing (`timing.json`). Default engine **`local`** aligns the known narration text against the mp3 offline (ffmpeg silencedetect, no API); **`--engine whisper`** keeps OpenAI whisper-1 transcription. Both emit the same Whisper-shaped blocks.
 - **`image-generate`** — render scene-spec **image elements** (`image:` + `prompt:` boxes) via the OpenAI Images API into the bundle (also runs for missing assets inside `generate-all`).

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ docgen validate --pre-push
 | Command | Description |
 |---------|-------------|
 | `docgen init [TARGET_DIR] [--defaults] [--segments-file FILE]` | Scaffold a new project: `docgen.yaml`, wrapper scripts, directories |
-| `docgen wizard [--port 8501]` | Local web GUI: pick **focus files** per segment (persists to hint `context.paths` + `yaml-generate`), draft narration, review/approve, rerun TTS → timestamps → scene-spec → Manim → compose |
+| `docgen wizard [--port 8501]` | Local web GUI: focus files, **revise narration in place**, asset freshness chips, **rebuild-from-here** (default cascade: TTS → timestamps → scene-retime → Manim → compose → validate; LLM scene-spec is explicit) |
 | `docgen tts [--segment 01] [--dry-run]` | Generate TTS audio |
 | `docgen timestamps [--engine local\|whisper]` | Extract word/segment timestamps from TTS audio → `timing.json` (default `local`: offline narration-text alignment; `whisper`: OpenAI transcription) |
 | `docgen image-generate [--segment 01 \| --all \| --spec PATH] [--force] [--dry-run] [--model …] [--size …]` | Generate scene-spec image assets (`image:` + `prompt:` boxes) via the OpenAI Images API into the bundle |

--- a/src/docgen/asset_graph.py
+++ b/src/docgen/asset_graph.py
@@ -1,0 +1,340 @@
+"""Per-segment pipeline asset graph (freshness + rebuild-from-here).
+
+Used by the wizard to show which redo steps are fresh/stale/missing and to
+cascade ``run`` from a chosen step through validate. Aligns with CLI
+``generate-all`` defaults: after timestamps prefer offline ``scene-retime``
+(LLM ``scene-spec`` remains an explicit expensive step).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from docgen.config import Config
+
+# Default cascade after timestamps (offline retime, not OpenAI scene-spec).
+DEFAULT_CASCADE: tuple[str, ...] = (
+    "tts",
+    "timestamps",
+    "scene-retime",
+    "manim",
+    "compose",
+    "validate",
+)
+
+# LLM scene-spec replaces scene-retime when the maintainer opts into regen.
+LLM_SCENE_CASCADE: tuple[str, ...] = (
+    "tts",
+    "timestamps",
+    "scene-spec",
+    "manim",
+    "compose",
+    "validate",
+)
+
+KNOWN_STEPS = frozenset(
+    {
+        "tts",
+        "timestamps",
+        "scene-retime",
+        "scene-spec",
+        "manim",
+        "compose",
+        "validate",
+    }
+)
+
+
+@dataclass(frozen=True)
+class StepStatus:
+    step: str
+    status: str  # fresh | stale | missing | n/a
+    detail: str
+    path: str | None = None
+    mtime: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def cascade_steps(start: str, *, llm_scene_spec: bool = False) -> list[str]:
+    """Return ordered steps from ``start`` inclusive through validate.
+
+    ``start="scene-spec"`` always continues with the LLM cascade tail
+    (manim → compose → validate), even when the default chain uses retime.
+    """
+    start = str(start).strip()
+    if start not in KNOWN_STEPS:
+        raise ValueError(f"unknown pipeline step: {start!r}")
+
+    if start == "scene-spec":
+        order = list(LLM_SCENE_CASCADE)
+    elif llm_scene_spec:
+        order = list(LLM_SCENE_CASCADE)
+    else:
+        order = list(DEFAULT_CASCADE)
+
+    if start not in order:
+        # e.g. start=scene-retime while llm_scene_spec=True — use default chain.
+        order = list(DEFAULT_CASCADE)
+    idx = order.index(start)
+    return order[idx:]
+
+
+def _mtime(path: Path | None) -> float | None:
+    if path is None or not path.is_file():
+        return None
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return None
+
+
+def _rel(cfg: "Config", path: Path | None) -> str | None:
+    if path is None:
+        return None
+    try:
+        return str(path.relative_to(cfg.base_dir))
+    except ValueError:
+        return str(path)
+
+
+def _find_asset(directory: Path, seg_name: str, seg_id: str, ext: str) -> Path | None:
+    if not directory.exists():
+        return None
+    exact = directory / f"{seg_name}{ext}"
+    if exact.exists():
+        return exact
+    exact_id = directory / f"{seg_id}{ext}"
+    if exact_id.exists():
+        return exact_id
+    for f in directory.glob(f"{seg_id}-*{ext}"):
+        return f
+    for f in directory.glob(f"{seg_id}*{ext}"):
+        return f
+    return None
+
+
+def _timing_entry_exists(cfg: "Config", seg_name: str, audio: Path | None) -> bool:
+    timing_path = cfg.animations_dir / "timing.json"
+    if not timing_path.is_file():
+        return False
+    try:
+        data = json.loads(timing_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    if seg_name in data:
+        return True
+    if audio is not None and audio.stem in data:
+        return True
+    return False
+
+
+def _scene_spec_path(cfg: "Config", seg_id: str, seg_name: str) -> Path | None:
+    from docgen.scene_retime import list_scene_spec_paths
+
+    paths = list_scene_spec_paths(cfg, segment_id=seg_id)
+    if paths:
+        return paths[0]
+    # Fall back to conventional stem even if missing (for path reporting).
+    candidate = cfg.animations_dir / "specs" / f"{seg_name}.scene.yaml"
+    return candidate if candidate.is_file() else None
+
+
+def _manim_visual_path(cfg: "Config", seg_id: str) -> Path | None:
+    """Best-effort Manim/composed visual input path for freshness."""
+    vmap = cfg.visual_map.get(seg_id, {})
+    if not isinstance(vmap, dict):
+        return None
+    src = str(vmap.get("source", "")).strip()
+    if src:
+        for candidate in (cfg.animations_dir / src, cfg.base_dir / src):
+            if candidate.is_file():
+                return candidate
+    # Search common Manim media layout for the scene class name.
+    scene = str(vmap.get("scene") or vmap.get("class") or "").strip()
+    media = cfg.animations_dir / "media" / "videos" / "scenes"
+    if scene and media.is_dir():
+        matches = sorted(media.rglob(f"{scene}.mp4"))
+        if matches:
+            return matches[0]
+    return None
+
+
+def _status(
+    *,
+    step: str,
+    output: Path | None,
+    upstream_mtimes: list[float | None],
+    cfg: "Config",
+    missing_detail: str,
+    fresh_detail: str,
+) -> StepStatus:
+    out_m = _mtime(output)
+    if out_m is None:
+        return StepStatus(step, "missing", missing_detail, path=_rel(cfg, output))
+    ups = [m for m in upstream_mtimes if m is not None]
+    if ups and out_m < max(ups) - 1.0:
+        return StepStatus(
+            step,
+            "stale",
+            "output older than an upstream input",
+            path=_rel(cfg, output),
+            mtime=out_m,
+        )
+    return StepStatus(
+        step, "fresh", fresh_detail, path=_rel(cfg, output), mtime=out_m
+    )
+
+
+def segment_step_statuses(cfg: "Config", seg_id: str) -> list[StepStatus]:
+    """Compute freshness for each wizard pipeline step for ``seg_id``."""
+    sid = str(seg_id).strip()
+    if sid.isdigit():
+        sid = sid.zfill(2)
+    seg_name = cfg.resolve_segment_name(sid)
+
+    narration = _find_asset(cfg.narration_dir, seg_name, sid, ".md")
+    audio = _find_asset(cfg.audio_dir, seg_name, sid, ".mp3")
+    timing_path = cfg.animations_dir / "timing.json"
+    timing_ok = _timing_entry_exists(cfg, seg_name, audio)
+    spec = _scene_spec_path(cfg, sid, seg_name)
+    visual = _manim_visual_path(cfg, sid)
+    recording = _find_asset(cfg.recordings_dir, seg_name, sid, ".mp4")
+
+    narr_m = _mtime(narration)
+    audio_m = _mtime(audio)
+    timing_m = _mtime(timing_path) if timing_ok else None
+    spec_m = _mtime(spec)
+    visual_m = _mtime(visual)
+    rec_m = _mtime(recording)
+
+    out: list[StepStatus] = []
+
+    # TTS
+    if narration is None:
+        out.append(StepStatus("tts", "missing", "no narration.md yet"))
+    else:
+        out.append(
+            _status(
+                step="tts",
+                output=audio,
+                upstream_mtimes=[narr_m],
+                cfg=cfg,
+                missing_detail="no audio mp3 — run TTS",
+                fresh_detail="audio newer than (or equal to) narration",
+            )
+        )
+
+    # Timestamps
+    if audio is None:
+        out.append(StepStatus("timestamps", "missing", "no audio — run TTS first"))
+    elif not timing_ok:
+        out.append(
+            StepStatus(
+                "timestamps",
+                "missing",
+                "no timing.json entry — run timestamps",
+                path=_rel(cfg, timing_path),
+            )
+        )
+    else:
+        out.append(
+            _status(
+                step="timestamps",
+                output=timing_path,
+                upstream_mtimes=[audio_m],
+                cfg=cfg,
+                missing_detail="no timing.json",
+                fresh_detail="timing.json newer than (or equal to) audio",
+            )
+        )
+
+    # Scene retime / scene-spec share the same output artifact (*.scene.yaml + scenes.py).
+    # Freshness is relative to narration + timing.
+    for step_name in ("scene-retime", "scene-spec"):
+        if not timing_ok and audio is None:
+            out.append(
+                StepStatus(step_name, "missing", "need audio + timestamps first")
+            )
+        elif spec is None:
+            out.append(
+                StepStatus(
+                    step_name,
+                    "missing",
+                    "no animations/specs/*.scene.yaml",
+                )
+            )
+        else:
+            out.append(
+                _status(
+                    step=step_name,
+                    output=spec,
+                    upstream_mtimes=[narr_m, timing_m],
+                    cfg=cfg,
+                    missing_detail="no scene spec",
+                    fresh_detail="scene spec newer than narration/timing",
+                )
+            )
+
+    # Manim
+    vt = str(cfg.visual_map.get(sid, {}).get("type", "")).strip().lower()
+    if vt and vt != "manim":
+        out.append(StepStatus("manim", "n/a", f"visual type {vt!r} (not manim)"))
+    else:
+        out.append(
+            _status(
+                step="manim",
+                output=visual,
+                upstream_mtimes=[spec_m, timing_m],
+                cfg=cfg,
+                missing_detail="no Manim visual mp4 — run manim",
+                fresh_detail="visual newer than scene spec/timing",
+            )
+        )
+
+    # Compose
+    out.append(
+        _status(
+            step="compose",
+            output=recording,
+            upstream_mtimes=[audio_m, visual_m],
+            cfg=cfg,
+            missing_detail="no recording — run compose",
+            fresh_detail="recording newer than audio/visual",
+        )
+    )
+
+    # Validate is advisory — always runnable
+    out.append(
+        StepStatus(
+            "validate",
+            "n/a",
+            "run to check drift / timing_sync / story_end / av_sync",
+            path=_rel(cfg, recording),
+            mtime=rec_m,
+        )
+    )
+    return out
+
+
+def segment_asset_report(cfg: "Config", seg_id: str) -> dict[str, Any]:
+    """JSON-serializable asset graph summary for the wizard."""
+    statuses = segment_step_statuses(cfg, seg_id)
+    stale_or_missing = [
+        s.step for s in statuses if s.status in ("stale", "missing")
+    ]
+    return {
+        "segment_id": str(seg_id).strip().zfill(2)
+        if str(seg_id).strip().isdigit()
+        else str(seg_id).strip(),
+        "steps": [s.to_dict() for s in statuses],
+        "default_cascade": list(DEFAULT_CASCADE),
+        "stale_or_missing": stale_or_missing,
+    }

--- a/src/docgen/manim_scene_support.py
+++ b/src/docgen/manim_scene_support.py
@@ -183,10 +183,14 @@ def _box(label, color, w=2.2, h=0.75, fs=18):
     return VGroup(r, t)
 
 
-def _arrow(start, end, color="#cdd6f4"):
-    """Connector between box centers (used by scene-spec ``edges``)."""
+def _arrow(start, end, color="#cdd6f4", style="solid"):
+    """Connector between box centers (used by scene-spec ``edges``).
+
+    ``style`` is ``solid`` (default) or ``dashed``. Dashed edges should be
+    revealed with ``FadeIn`` (not ``GrowArrow``).
+    """
     # Allow palette token names that compile_scene_class emits as bare identifiers.
-    return Arrow(
+    arr = Arrow(
         start,
         end,
         color=color,
@@ -194,6 +198,9 @@ def _arrow(start, end, color="#cdd6f4"):
         buff=0.2,
         max_tip_length_to_length_ratio=0.15,
     )
+    if str(style).strip().lower() == "dashed":
+        return DashedVMobject(arr, num_dashes=18, dashed_ratio=0.55)
+    return arr
 
 
 def _image(relpath, w=3.0, h=2.0):

--- a/src/docgen/scene_spec.py
+++ b/src/docgen/scene_spec.py
@@ -55,6 +55,7 @@ ALLOWED_COLORS = frozenset(
 )
 
 ALLOWED_PAGE_TRANSITIONS = frozenset({"fade", "none"})
+ALLOWED_EDGE_STYLES = frozenset({"solid", "dashed"})
 
 SPEC_REQUIRED_TOP = ("segment_id", "class_name", "title")
 
@@ -1164,6 +1165,17 @@ def _validate_edges(
             raise SceneSpecError(
                 f"{ep}: color must be one of {sorted(ALLOWED_COLORS)} if set"
             )
+        style = edge.get("style")
+        if style is not None and str(style).strip().lower() not in ALLOWED_EDGE_STYLES:
+            raise SceneSpecError(
+                f"{ep}: style must be one of {sorted(ALLOWED_EDGE_STYLES)} if set"
+            )
+        label = edge.get("label")
+        if label is not None:
+            if not isinstance(label, str):
+                raise SceneSpecError(f"{ep}: label must be a string if set")
+            if len(label.strip()) > 40:
+                raise SceneSpecError(f"{ep}: label must be at most 40 characters")
 
 
 def validate_scene_spec(data: dict[str, Any], *, path_label: str = "spec") -> None:
@@ -1348,8 +1360,8 @@ def compile_scene_class(spec: dict[str, Any]) -> str:
         "",
     ]
 
-    # Map (page, later-box-var) → list of edge var names to GrowArrow with that box.
-    edges_with_target: dict[tuple[int, str], list[str]] = {}
+    # Map (page, later-box-var) → list of (edge_var, anim) where anim is grow|fade.
+    edges_with_target: dict[tuple[int, str], list[tuple[str, str]]] = {}
     page_edge_vars: dict[int, list[str]] = {}
 
     for p, page in enumerate(pages):
@@ -1416,14 +1428,29 @@ def compile_scene_class(spec: dict[str, Any]) -> str:
                 continue
             evar = f"_ar_{p}_{ei}"
             ecol = str(edge.get("color") or "C_ACCENT")
+            estyle = str(edge.get("style") or "solid").strip().lower() or "solid"
+            elabel = str(edge.get("label") or "").strip()
             lines.append(
-                f"        {evar} = _arrow({src_var}.get_center(), {dst_var}.get_center(), {ecol})"
+                f"        {evar} = _arrow({src_var}.get_center(), {dst_var}.get_center(), "
+                f"{ecol}, style={estyle!r})"
             )
             page_edge_vars.setdefault(p, []).append(evar)
             # Reveal with the later endpoint (second in box creation order).
             order = {v: i for i, v in enumerate(label_vars.values())}
             later = dst_var if order.get(dst_var, 0) >= order.get(src_var, 0) else src_var
-            edges_with_target.setdefault((p, later), []).append(evar)
+            # GrowArrow only works on solid Arrow; dashed / labeled edges FadeIn.
+            anim = "grow" if estyle == "solid" and not elabel else "fade"
+            edges_with_target.setdefault((p, later), []).append((evar, anim))
+            if elabel:
+                lvar = f"{evar}_lbl"
+                lines.append(
+                    f"        {lvar} = Text({elabel!r}, font_size=16, color={ecol})"
+                )
+                lines.append(
+                    f"        {lvar}.move_to({evar}.get_center()).shift(UP * 0.22)"
+                )
+                page_edge_vars.setdefault(p, []).append(lvar)
+                edges_with_target.setdefault((p, later), []).append((lvar, "fade"))
 
     lines.append("")
 
@@ -1459,11 +1486,15 @@ def compile_scene_class(spec: dict[str, Any]) -> str:
                             lines.append(f"        self.remove({t})")
                         lines.append("        self.timed_wait(0.05)")
                 bx = f"_bx_{p}_{r}_{b_idx}"
-                edge_vars = edges_with_target.get((p, bx), [])
-                if edge_vars:
-                    anims = ", ".join(
-                        [f"FadeIn({bx})"] + [f"GrowArrow({ev})" for ev in edge_vars]
-                    )
+                edge_anims = edges_with_target.get((p, bx), [])
+                if edge_anims:
+                    parts = [f"FadeIn({bx})"]
+                    for ev, kind in edge_anims:
+                        if kind == "grow":
+                            parts.append(f"GrowArrow({ev})")
+                        else:
+                            parts.append(f"FadeIn({ev})")
+                    anims = ", ".join(parts)
                     lines.append(
                         f"        self.timed_play({anims}, run_time={run_time})"
                     )

--- a/src/docgen/scene_spec_generate.py
+++ b/src/docgen/scene_spec_generate.py
@@ -105,8 +105,9 @@ Optional top-level:
 - edges: optional list of connectors for **single-page** ``rows`` specs (see below).
 
 Optional per-page (when using ``pages``):
-- edges: list of {{ from: <box label>, to: <box label>, color?: <palette token> }}
-  drawn as arrows between those boxes after layout. Labels must be unique on that page.
+- edges: list of {{ from: <box label>, to: <box label>, color?: <palette token>,
+  style?: solid|dashed, label?: short edge caption ≤40 chars }}
+  drawn as arrows between those boxes after layout. Box labels must be unique on that page.
   Prefer edges for pipeline / flow diagrams (A → B → C); omit when boxes are unrelated topics.
 
 Use either **rows** (single page) OR **pages** (list of {{ rows: [...], transition?: fade|none, edges?: [...] }} — transition on pages after the first overrides layout.page_transition for exiting the previous page; first page has no transition in).
@@ -119,6 +120,8 @@ Design goals:
 - **Rows** within a page stack vertically; multiple boxes in one row arrange horizontally with safe spacing.
 - **Edges / arrows:** when narration describes a flow or pipeline, add ``edges`` so the board shows
   directed connections (not only isolated boxes). Keep edge endpoints as spoken labels.
+  Use ``style: dashed`` for optional/secondary paths and a short ``label`` on the arrow when
+  the narration names the relationship (keep edge captions terse).
 - **Subject-beat coverage (mandatory):** consecutive sentences on the same topic are one beat —
   **hold the board**. When the topic shifts, reveal a new spoken-phrase label for that beat.
   Do **not** invent a box per sentence, and do **not** leave a new topic without a matching label.

--- a/src/docgen/static/wizard.css
+++ b/src/docgen/static/wizard.css
@@ -47,6 +47,9 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,san
 .btn-primary:disabled{background:#a0b0e0;cursor:not-allowed}
 .btn-secondary{background:#e8ecf4;color:#333}.btn-secondary:hover{background:#d0d8ea}
 .btn-warning{background:#f59e0b;color:#fff}.btn-warning:hover{background:#d97706}
+.video-actions .step-stale{box-shadow:inset 0 0 0 1px #f59e0b}
+.video-actions .step-missing{box-shadow:inset 0 0 0 1px #ef4444}
+.video-actions .step-fresh{opacity:.92}
 .action-bar{display:flex;align-items:center;gap:1rem;margin-top:1rem}
 .status-text{font-size:.82rem;color:#666}
 
@@ -104,6 +107,16 @@ textarea:focus,input[type=text]:focus{outline:none;border-color:#4361ee;box-shad
 .validation-card h3{font-size:.88rem;margin-bottom:.4rem}
 .validation-card pre{font-size:.78rem;white-space:pre-wrap;max-height:200px;overflow-y:auto;background:#f8f9fc;padding:.5rem;border-radius:4px}
 .video-actions{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.75rem}
+.asset-graph{margin-top:.75rem;padding:.75rem;border:1px solid #e8ecf4;border-radius:8px;background:#fafbff}
+.asset-step-list{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;margin:.4rem 0 0}
+.asset-chip{font-size:.72rem;padding:.2rem .55rem;border-radius:999px;font-weight:600;letter-spacing:.02em;border:1px solid transparent}
+.asset-chip.fresh{background:#d1fae5;color:#065f46;border-color:#a7f3d0}
+.asset-chip.stale{background:#fef3c7;color:#92400e;border-color:#fde68a}
+.asset-chip.missing{background:#fee2e2;color:#991b1b;border-color:#fecaca}
+.asset-chip.na{background:#e8ecf4;color:#666;border-color:#d0d8ea}
+.rebuild-row{display:flex;flex-wrap:wrap;align-items:center;gap:.5rem;margin-top:.75rem}
+.rebuild-row label{font-size:.82rem;color:#666}
+.rebuild-row select{border:1px solid #ddd;border-radius:6px;padding:.35rem .5rem;font-size:.85rem;background:#fff}
 
 /* Review action bar */
 .review-action-bar{display:flex;flex-wrap:wrap;align-items:center;gap:.75rem;margin-top:1.5rem;padding-top:1rem;border-top:1px solid #e8ecf4}

--- a/src/docgen/static/wizard.js
+++ b/src/docgen/static/wizard.js
@@ -485,6 +485,45 @@
     }
 
     document.getElementById("validation-results").innerHTML = '<p class="hint">Run validate to see results.</p>';
+    renderAssetGraph(seg?.assets);
+  }
+
+  function renderAssetGraph(assets) {
+    const list = document.getElementById("asset-step-list");
+    if (!list) return;
+    list.innerHTML = "";
+    const steps = assets?.steps || [];
+    if (!steps.length) {
+      const li = document.createElement("li");
+      li.className = "hint";
+      li.textContent = "No asset status yet.";
+      list.appendChild(li);
+      return;
+    }
+    // Prefer one chip per logical stage (skip duplicate scene-spec when showing retime).
+    const prefer = new Set(["tts", "timestamps", "scene-retime", "manim", "compose", "validate"]);
+    for (const s of steps) {
+      if (!prefer.has(s.step) && s.step !== "scene-spec") continue;
+      if (s.step === "scene-spec") continue; // shown via retime chip; LLM is explicit button
+      const li = document.createElement("li");
+      const st = s.status === "n/a" ? "na" : s.status;
+      li.className = "asset-chip " + st;
+      li.title = s.detail || "";
+      li.textContent = s.step + ": " + s.status;
+      list.appendChild(li);
+    }
+    // Highlight redo buttons by data-step
+    const byStep = Object.fromEntries(steps.map((s) => [s.step, s]));
+    document.querySelectorAll(".video-actions [data-step]").forEach((btn) => {
+      const step = btn.getAttribute("data-step");
+      const info = byStep[step];
+      btn.classList.remove("step-stale", "step-missing", "step-fresh");
+      if (!info) return;
+      if (info.status === "stale") btn.classList.add("step-stale");
+      else if (info.status === "missing") btn.classList.add("step-missing");
+      else if (info.status === "fresh") btn.classList.add("step-fresh");
+      btn.title = (btn.title ? btn.title + " — " : "") + (info.detail || info.status);
+    });
   }
 
   document.getElementById("btn-add-focus-path")?.addEventListener("click", () => {
@@ -533,33 +572,54 @@
     });
   });
 
-  document.getElementById("btn-regen-narration").addEventListener("click", async () => {
+  async function generateOrReviseNarration(mode) {
     if (!activeSegmentId) return;
     const notes = document.getElementById("revision-notes").value;
     const guidance = document.getElementById("guidance")?.value || "";
+    const current = document.getElementById("narration-editor").value || "";
     const seg = prodSegments.find((s) => s.id === activeSegmentId);
-    const btn = document.getElementById("btn-regen-narration");
-    btn.textContent = "Regenerating...";
-    btn.disabled = true;
+    const regenBtn = document.getElementById("btn-regen-narration");
+    const reviseBtn = document.getElementById("btn-revise-narration");
+    const activeBtn = mode === "revise" ? reviseBtn : regenBtn;
+    const idleLabel = mode === "revise" ? "Revise narration" : "Regenerate";
+    if (mode === "revise" && !notes.trim()) {
+      alert("Revision notes are required to revise in place.");
+      return;
+    }
+    if (mode === "revise" && !current.trim()) {
+      alert("Editor is empty — use Regenerate for a full draft, or paste a script first.");
+      return;
+    }
+    activeBtn.textContent = mode === "revise" ? "Revising..." : "Regenerating...";
+    regenBtn.disabled = true;
+    reviseBtn.disabled = true;
     try {
+      const body = {
+        source_paths: prodFocusPaths.length ? prodFocusPaths : (seg?.focus_paths || []),
+        guidance,
+        segment_name: seg?.name || activeSegmentId,
+        segment_id: activeSegmentId,
+        revision_notes: notes,
+        mode,
+      };
+      if (mode === "revise") body.current_narration = current;
       const res = await fetch("/api/generate-narration", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          source_paths: prodFocusPaths.length ? prodFocusPaths : (seg?.focus_paths || []),
-          guidance,
-          segment_name: seg?.name || activeSegmentId,
-          segment_id: activeSegmentId,
-          revision_notes: notes,
-        }),
+        body: JSON.stringify(body),
       });
       const data = await res.json();
       if (data.error) throw new Error(data.error);
       if (data.narration) document.getElementById("narration-editor").value = data.narration;
     } catch (err) { alert("Error: " + err.message); }
-    btn.textContent = "Regenerate narration";
-    btn.disabled = false;
-  });
+    regenBtn.textContent = "Regenerate";
+    reviseBtn.textContent = "Revise narration";
+    regenBtn.disabled = false;
+    reviseBtn.disabled = false;
+  }
+
+  document.getElementById("btn-regen-narration").addEventListener("click", () => generateOrReviseNarration("generate"));
+  document.getElementById("btn-revise-narration")?.addEventListener("click", () => generateOrReviseNarration("revise"));
 
   // ---- Pipeline step buttons ----
   async function runStep(step) {
@@ -571,8 +631,39 @@
     return data;
   }
 
-  document.getElementById("btn-redo-tts").addEventListener("click", () => runStep("tts"));
+  async function runFrom(step) {
+    if (!activeSegmentId) return null;
+    const status = document.getElementById("rebuild-status");
+    if (status) status.textContent = "Running from " + step + "…";
+    const llm = step === "scene-spec";
+    const res = await fetch(
+      "/api/run-from/" + encodeURIComponent(step) + "/" + encodeURIComponent(activeSegmentId),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ llm_scene_spec: llm }),
+      }
+    );
+    const data = await res.json();
+    if (!res.ok || data.error) {
+      if (status) status.textContent = "Failed at " + (data.failed_step || step);
+      alert((data.failed_step || step) + " error: " + (data.error || res.status));
+    } else {
+      if (status) status.textContent = "Done (" + (data.ran || []).length + " steps)";
+      const validateRun = (data.ran || []).find((r) => r.step === "validate" && r.report);
+      if (validateRun?.report) {
+        document.getElementById("validation-results").innerHTML =
+          "<pre>" + escHtml(JSON.stringify(validateRun.report, null, 2)) + "</pre>";
+      }
+      await loadProductionView();
+    }
+    return data;
+  }
+
+  document.getElementById("btn-redo-tts")?.addEventListener("click", () => runStep("tts"));
+  document.getElementById("btn-redo-tts-video")?.addEventListener("click", () => runStep("tts"));
   document.getElementById("btn-redo-timestamps")?.addEventListener("click", () => runStep("timestamps"));
+  document.getElementById("btn-redo-scene-retime")?.addEventListener("click", () => runStep("scene-retime"));
   document.getElementById("btn-redo-scene-spec")?.addEventListener("click", () => runStep("scene-spec"));
   document.getElementById("btn-redo-manim").addEventListener("click", () => runStep("manim"));
   document.getElementById("btn-redo-compose").addEventListener("click", () => runStep("compose"));
@@ -584,11 +675,15 @@
     }
   });
 
+  document.getElementById("btn-rebuild-from")?.addEventListener("click", async () => {
+    const sel = document.getElementById("rebuild-from-select");
+    const step = sel?.value || "scene-retime";
+    await runFrom(step);
+  });
+
   document.getElementById("btn-redo-all").addEventListener("click", async () => {
     if (!activeSegmentId) return;
-    for (const step of ["tts", "timestamps", "scene-spec", "manim", "compose", "validate"]) {
-      await runStep(step);
-    }
+    await runFrom("tts");
   });
 
   // ---- Status buttons ----

--- a/src/docgen/templates/wizard.html
+++ b/src/docgen/templates/wizard.html
@@ -94,8 +94,9 @@
           <div class="narration-actions">
             <button id="btn-save-narration" class="btn btn-secondary">Save</button>
             <div class="revision-row">
-              <input id="revision-notes" type="text" placeholder="Revision notes for regeneration (optional)...">
-              <button id="btn-regen-narration" class="btn btn-secondary">Regenerate narration</button>
+              <input id="revision-notes" type="text" placeholder="Revision notes (required for Revise)…">
+              <button id="btn-revise-narration" class="btn btn-primary" title="Edit the current script in place using revision notes">Revise narration</button>
+              <button id="btn-regen-narration" class="btn btn-secondary" title="Full rewrite from focus files + sources">Regenerate</button>
             </div>
           </div>
         </div>
@@ -140,17 +141,37 @@
               </div>
             </div>
           </div>
+          <div id="asset-graph" class="asset-graph" aria-live="polite">
+            <p class="hint">Pipeline freshness (mtime vs upstream). Stale/missing steps need a rebuild.</p>
+            <ul id="asset-step-list" class="asset-step-list"></ul>
+          </div>
           <div class="video-actions">
-            <button id="btn-redo-timestamps" class="btn btn-secondary">Redo timestamps</button>
-            <button id="btn-redo-scene-spec" class="btn btn-secondary">Regen scene spec</button>
-            <button id="btn-redo-manim" class="btn btn-secondary">Redo Manim</button>
-            <button id="btn-redo-compose" class="btn btn-secondary">Redo compose</button>
-            <button id="btn-run-validate" class="btn btn-secondary">Run validate</button>
+            <button id="btn-redo-tts-video" class="btn btn-secondary" data-step="tts">TTS</button>
+            <button id="btn-redo-timestamps" class="btn btn-secondary" data-step="timestamps">Timestamps</button>
+            <button id="btn-redo-scene-retime" class="btn btn-secondary" data-step="scene-retime" title="Offline retime existing scene specs against timing.json">Retime scenes</button>
+            <button id="btn-redo-scene-spec" class="btn btn-secondary" data-step="scene-spec" title="LLM regen of scene YAML (expensive)">Regen scene spec</button>
+            <button id="btn-redo-manim" class="btn btn-secondary" data-step="manim">Manim</button>
+            <button id="btn-redo-compose" class="btn btn-secondary" data-step="compose">Compose</button>
+            <button id="btn-run-validate" class="btn btn-secondary" data-step="validate">Validate</button>
+          </div>
+          <div class="rebuild-row">
+            <label for="rebuild-from-select">Rebuild from</label>
+            <select id="rebuild-from-select">
+              <option value="tts">TTS</option>
+              <option value="timestamps">Timestamps</option>
+              <option value="scene-retime" selected>Retime scenes</option>
+              <option value="scene-spec">Regen scene spec (LLM)</option>
+              <option value="manim">Manim</option>
+              <option value="compose">Compose</option>
+              <option value="validate">Validate</option>
+            </select>
+            <button id="btn-rebuild-from" class="btn btn-warning">Rebuild from here</button>
+            <span id="rebuild-status" class="status-text"></span>
           </div>
         </div>
 
         <div class="review-action-bar">
-          <button id="btn-redo-all" class="btn btn-warning">Redo all steps</button>
+          <button id="btn-redo-all" class="btn btn-warning" title="TTS → timestamps → scene-retime → manim → compose → validate">Rebuild all (retime)</button>
           <button id="btn-flag-rework" class="btn btn-secondary">Flag for rework</button>
           <button id="btn-approve" class="btn btn-primary">Mark approved</button>
           <div class="nav-btns">

--- a/src/docgen/wizard.py
+++ b/src/docgen/wizard.py
@@ -178,40 +178,104 @@ def generate_narration_via_llm(
     *,
     temperature: float = 0.7,
     topic_label: str | None = None,
+    current_narration: str = "",
+    mode: str = "generate",
 ) -> str:
-    """Call OpenAI to generate a narration draft from source docs + guidance.
+    """Call OpenAI to generate or revise a narration draft.
 
     ``guidance`` is **caller-supplied** (e.g. project-owner hints from ``docgen.yaml``), not
     text returned from a prior model call. ``topic_label`` is a human-facing focus
     line (e.g. ``Config.narration_topic_label``); when present it is what the model
     sees in the user prompt so spoken output never echoes file stems / segment ids.
+
+    ``mode="revise"`` (or auto when ``current_narration`` + ``revision_notes`` are
+    both non-empty) edits the existing script in place: address feedback, keep
+    structure/phrasing that still work, do not rewrite from scratch unless needed.
     """
     import openai
 
     focus = (topic_label or "").strip() or _strip_segment_prefix(segment_name)
-    user_parts = [
-        f"Write a narration script focused on: {focus}.",
-        "Do not mention segment numbers, file stems, ordinals, or any 'segment NN' phrasing.",
-        "",
-        "--- SOURCE DOCUMENTATION ---",
-        *source_texts,
-        "--- END SOURCE DOCUMENTATION ---",
-    ]
-    if guidance:
-        user_parts += ["", "--- PROJECT OWNER HINTS ---", guidance, "--- END PROJECT OWNER HINTS ---"]
-    if revision_notes:
+    notes = (revision_notes or "").strip()
+    current = (current_narration or "").strip()
+    mode_norm = str(mode or "generate").strip().lower()
+    if mode_norm not in ("generate", "revise"):
+        mode_norm = "generate"
+    # Auto-revise when the caller supplied both an existing script and notes.
+    if mode_norm == "generate" and current and notes:
+        mode_norm = "revise"
+
+    if mode_norm == "revise":
+        if not current:
+            raise ValueError("revise mode requires current_narration text")
+        if not notes:
+            raise ValueError("revise mode requires revision_notes")
+        user_parts = [
+            f"Revise the narration script focused on: {focus}.",
+            "Edit the CURRENT NARRATION in place: address the revision notes, "
+            "preserve structure and phrasing that still work, and do not rewrite "
+            "from scratch unless the notes require it.",
+            "Do not mention segment numbers, file stems, ordinals, or any 'segment NN' phrasing.",
+            "Return only the revised narration markdown (no preamble).",
+            "",
+            "--- CURRENT NARRATION ---",
+            current,
+            "--- END CURRENT NARRATION ---",
+        ]
+        if source_texts:
+            user_parts += [
+                "",
+                "--- SOURCE DOCUMENTATION (reference only) ---",
+                *source_texts,
+                "--- END SOURCE DOCUMENTATION ---",
+            ]
+        if guidance:
+            user_parts += [
+                "",
+                "--- PROJECT OWNER HINTS ---",
+                guidance,
+                "--- END PROJECT OWNER HINTS ---",
+            ]
         user_parts += [
             "",
             "--- REVISION NOTES (address these) ---",
-            revision_notes,
+            notes,
             "--- END REVISION NOTES ---",
         ]
+        sys_prompt = (
+            system_prompt
+            + "\nYou are revising an existing narration script. Prefer minimal edits "
+            "that satisfy the revision notes over a full rewrite."
+        )
+    else:
+        user_parts = [
+            f"Write a narration script focused on: {focus}.",
+            "Do not mention segment numbers, file stems, ordinals, or any 'segment NN' phrasing.",
+            "",
+            "--- SOURCE DOCUMENTATION ---",
+            *source_texts,
+            "--- END SOURCE DOCUMENTATION ---",
+        ]
+        if guidance:
+            user_parts += [
+                "",
+                "--- PROJECT OWNER HINTS ---",
+                guidance,
+                "--- END PROJECT OWNER HINTS ---",
+            ]
+        if notes:
+            user_parts += [
+                "",
+                "--- REVISION NOTES (address these) ---",
+                notes,
+                "--- END REVISION NOTES ---",
+            ]
+        sys_prompt = system_prompt
 
     client = openai.OpenAI()
     response = client.chat.completions.create(
         model=model,
         messages=[
-            {"role": "system", "content": system_prompt},
+            {"role": "system", "content": sys_prompt},
             {"role": "user", "content": "\n".join(user_parts)},
         ],
         temperature=float(temperature),
@@ -313,6 +377,8 @@ def create_app(config: Any | None = None) -> Flask:
         guidance: str = data.get("guidance", "")
         segment_name: str = data.get("segment_name", "untitled")
         revision_notes: str = data.get("revision_notes", "")
+        current_narration: str = data.get("current_narration", "") or ""
+        mode: str = data.get("mode", "generate") or "generate"
         topic_label: str | None = data.get("topic_label") or None
         seg_id_hint: str | None = data.get("segment_id")
         if topic_label is None and cfg is not None and seg_id_hint:
@@ -359,7 +425,11 @@ def create_app(config: Any | None = None) -> Flask:
                 segment_name=segment_name,
                 revision_notes=revision_notes,
                 topic_label=topic_label,
+                current_narration=current_narration,
+                mode=mode,
             )
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
         except Exception as exc:
             return jsonify({"error": str(exc)}), 500
 
@@ -368,10 +438,17 @@ def create_app(config: Any | None = None) -> Flask:
         out = narration_dir / f"{segment_name}.md"
         out.write_text(narration + "\n", encoding="utf-8")
 
+        effective_mode = str(mode or "generate").strip().lower()
+        if effective_mode not in ("generate", "revise"):
+            effective_mode = "generate"
+        if effective_mode == "generate" and current_narration.strip() and revision_notes.strip():
+            effective_mode = "revise"
+
         return jsonify({
             "narration": narration,
             "path": str(out),
             "source_paths": source_paths,
+            "mode": effective_mode,
         })
 
     # -- API: segment state ----------------------------------------------------
@@ -416,6 +493,9 @@ def create_app(config: Any | None = None) -> Flask:
                 focus_paths = list(
                     merged_narration_from_source_settings(cfg, seg_id).context_paths
                 )
+            from docgen.asset_graph import segment_asset_report
+
+            assets = segment_asset_report(cfg, seg_id)
             result.append({
                 "id": seg_id,
                 "name": seg_name,
@@ -429,8 +509,19 @@ def create_app(config: Any | None = None) -> Flask:
                 "recording_path": str(rec_found.relative_to(base)) if rec_found else None,
                 "visual_map": cfg.visual_map.get(seg_id, {}),
                 "focus_paths": focus_paths,
+                "assets": assets,
             })
         return jsonify({"segments": result})
+
+    @app.route("/api/segments/<segment_id>/assets")
+    def api_segment_assets(segment_id: str):
+        """Return per-step freshness for rebuild-from-here UI."""
+        cfg = _cfg()
+        if not cfg:
+            return jsonify({"error": "no config"}), 400
+        from docgen.asset_graph import segment_asset_report
+
+        return jsonify(segment_asset_report(cfg, segment_id))
 
     @app.route("/api/segments/<segment_id>/focus")
     def api_get_focus(segment_id: str):
@@ -559,106 +650,177 @@ def create_app(config: Any | None = None) -> Flask:
 
     # -- API: run pipeline steps for a single segment --------------------------
 
+    def _run_segment_step(cfg: Any, step: str, segment_id: str) -> dict[str, Any]:
+        """Execute one pipeline step; raise on failure. Returns a result dict."""
+        if step == "tts":
+            from docgen.tts import TTSGenerator
+
+            TTSGenerator(cfg).generate(segment=segment_id)
+            return {"ok": True, "step": "tts", "segment": segment_id}
+
+        if step == "timestamps":
+            import json as _json
+
+            from docgen.timestamps import TimestampExtractor
+
+            seg_name = cfg.resolve_segment_name(segment_id)
+            mp3 = _find_asset(cfg.audio_dir, seg_name, segment_id, ".mp3")
+            if mp3 is None:
+                raise RuntimeError(
+                    f"no audio for segment {segment_id}; run TTS first"
+                )
+            ts = TimestampExtractor(cfg)
+            engine = ts.resolve_engine(None)
+            block = (
+                ts.extract(mp3) if engine == "whisper" else ts.extract_local(mp3)
+            )
+            out = cfg.animations_dir / "timing.json"
+            timing: dict = {}
+            if out.is_file():
+                try:
+                    timing = _json.loads(out.read_text(encoding="utf-8"))
+                except _json.JSONDecodeError:
+                    timing = {}
+            if not isinstance(timing, dict):
+                timing = {}
+            timing[mp3.stem] = block
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(
+                _json.dumps(timing, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            from docgen.manim_scene_support import sync_audio_tail_waits_in_scenes
+
+            sync_audio_tail_waits_in_scenes(cfg)
+            return {"ok": True, "step": "timestamps", "segment": segment_id}
+
+        if step == "scene-retime":
+            from docgen.scene_retime import list_scene_spec_paths, retime_compile_spec
+
+            paths = list_scene_spec_paths(cfg, segment_id=segment_id)
+            if not paths:
+                raise RuntimeError(
+                    f"no scene spec for segment {segment_id}; "
+                    "run scene-spec (LLM) first or add animations/specs/*.scene.yaml"
+                )
+            results = [retime_compile_spec(cfg, p) for p in paths]
+            return {
+                "ok": True,
+                "step": "scene-retime",
+                "segment": segment_id,
+                "compiled": [str(r.get("path")) for r in results],
+            }
+
+        if step == "scene-spec":
+            from docgen.scene_spec_generate import (
+                generate_scene_spec,
+                inject_class_block_into_scenes_py,
+                linted_class_block_from_spec,
+            )
+
+            res = generate_scene_spec(
+                cfg, segment_id, extra_paths=[], extra_hints=[]
+            )
+            specs_dir = cfg.animations_dir / "specs"
+            specs_dir.mkdir(parents=True, exist_ok=True)
+            wpath = specs_dir / f"{res.seg_name}.scene.yaml"
+            wpath.write_text(res.yaml_text, encoding="utf-8")
+            class_block, merged = linted_class_block_from_spec(
+                cfg, res.spec, timing_key=res.seg_name
+            )
+            inject_class_block_into_scenes_py(
+                cfg,
+                seg_id=merged["segment_id"],
+                class_name=merged["class_name"],
+                class_block=class_block,
+            )
+            return {"ok": True, "step": "scene-spec", "segment": segment_id}
+
+        if step == "manim":
+            from docgen.manim_runner import ManimRunner
+
+            runner = ManimRunner(cfg)
+            vmap = cfg.visual_map.get(segment_id, {})
+            scene = vmap.get("scene")
+            if scene:
+                runner.render(scene=scene)
+            return {"ok": True, "step": "manim", "segment": segment_id}
+
+        if step == "compose":
+            from docgen.compose import Composer
+
+            Composer(cfg).compose_segments([segment_id])
+            return {"ok": True, "step": "compose", "segment": segment_id}
+
+        if step == "validate":
+            from docgen.validate import Validator
+
+            report = Validator(cfg).validate_segment(segment_id)
+            return {
+                "ok": True,
+                "step": "validate",
+                "segment": segment_id,
+                "report": report,
+            }
+
+        raise ValueError(f"Unknown step: {step}")
+
     @app.route("/api/run/<step>/<segment_id>", methods=["POST"])
     def api_run_step(step: str, segment_id: str):
         """Run a single pipeline step for one segment. Returns result or error."""
         cfg = _cfg()
         if not cfg:
             return jsonify({"error": "no config"}), 400
-
         try:
-            if step == "tts":
-                from docgen.tts import TTSGenerator
-                gen = TTSGenerator(cfg)
-                gen.generate(segment=segment_id)
-                return jsonify({"ok": True, "step": "tts", "segment": segment_id})
-
-            elif step == "timestamps":
-                import json as _json
-
-                from docgen.timestamps import TimestampExtractor
-
-                seg_name = cfg.resolve_segment_name(segment_id)
-                mp3 = _find_asset(cfg.audio_dir, seg_name, segment_id, ".mp3")
-                if mp3 is None:
-                    raise RuntimeError(
-                        f"no audio for segment {segment_id}; run TTS first"
-                    )
-                ts = TimestampExtractor(cfg)
-                engine = ts.resolve_engine(None)
-                block = (
-                    ts.extract(mp3) if engine == "whisper" else ts.extract_local(mp3)
-                )
-                out = cfg.animations_dir / "timing.json"
-                timing: dict = {}
-                if out.is_file():
-                    try:
-                        timing = _json.loads(out.read_text(encoding="utf-8"))
-                    except _json.JSONDecodeError:
-                        timing = {}
-                if not isinstance(timing, dict):
-                    timing = {}
-                timing[mp3.stem] = block
-                out.parent.mkdir(parents=True, exist_ok=True)
-                out.write_text(
-                    _json.dumps(timing, indent=2, ensure_ascii=False) + "\n",
-                    encoding="utf-8",
-                )
-                from docgen.manim_scene_support import sync_audio_tail_waits_in_scenes
-                sync_audio_tail_waits_in_scenes(cfg)
-                return jsonify({"ok": True, "step": "timestamps", "segment": segment_id})
-
-            elif step == "scene-spec":
-                from docgen.scene_spec_generate import (
-                    generate_scene_spec,
-                    inject_class_block_into_scenes_py,
-                    linted_class_block_from_spec,
-                )
-
-                res = generate_scene_spec(
-                    cfg, segment_id, extra_paths=[], extra_hints=[]
-                )
-                specs_dir = cfg.animations_dir / "specs"
-                specs_dir.mkdir(parents=True, exist_ok=True)
-                wpath = specs_dir / f"{res.seg_name}.scene.yaml"
-                wpath.write_text(res.yaml_text, encoding="utf-8")
-                class_block, merged = linted_class_block_from_spec(
-                    cfg, res.spec, timing_key=res.seg_name
-                )
-                inject_class_block_into_scenes_py(
-                    cfg,
-                    seg_id=merged["segment_id"],
-                    class_name=merged["class_name"],
-                    class_block=class_block,
-                )
-                return jsonify({"ok": True, "step": "scene-spec", "segment": segment_id})
-
-            elif step == "manim":
-                from docgen.manim_runner import ManimRunner
-                runner = ManimRunner(cfg)
-                vmap = cfg.visual_map.get(segment_id, {})
-                scene = vmap.get("scene")
-                if scene:
-                    runner.render(scene=scene)
-                return jsonify({"ok": True, "step": "manim", "segment": segment_id})
-
-            elif step == "compose":
-                from docgen.compose import Composer
-                comp = Composer(cfg)
-                comp.compose_segments([segment_id])
-                return jsonify({"ok": True, "step": "compose", "segment": segment_id})
-
-            elif step == "validate":
-                from docgen.validate import Validator
-                v = Validator(cfg)
-                report = v.validate_segment(segment_id)
-                return jsonify({"ok": True, "step": "validate", "segment": segment_id, "report": report})
-
-            else:
-                return jsonify({"error": f"Unknown step: {step}"}), 400
-
+            return jsonify(_run_segment_step(cfg, step, segment_id))
+        except ValueError as exc:
+            return jsonify({"error": str(exc), "step": step, "segment": segment_id}), 400
         except Exception as exc:
             return jsonify({"error": str(exc), "step": step, "segment": segment_id}), 500
+
+    @app.route("/api/run-from/<step>/<segment_id>", methods=["POST"])
+    def api_run_from(step: str, segment_id: str):
+        """Run ``step`` and all downstream cascade steps (rebuild-from-here).
+
+        Body (optional): ``{"llm_scene_spec": false}`` — when true, the cascade
+        uses LLM ``scene-spec`` instead of offline ``scene-retime``.
+        """
+        cfg = _cfg()
+        if not cfg:
+            return jsonify({"error": "no config"}), 400
+        data = request.json or {}
+        llm_scene = bool(data.get("llm_scene_spec", False))
+        from docgen.asset_graph import cascade_steps
+
+        try:
+            steps = cascade_steps(step, llm_scene_spec=llm_scene)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+
+        ran: list[dict[str, Any]] = []
+        for s in steps:
+            try:
+                result = _run_segment_step(cfg, s, segment_id)
+            except Exception as exc:
+                return jsonify({
+                    "ok": False,
+                    "error": str(exc),
+                    "failed_step": s,
+                    "ran": ran,
+                    "planned": steps,
+                    "segment": segment_id,
+                }), 500
+            ran.append({"step": s, "ok": True})
+            # Attach validate report on the final payload if present.
+            if s == "validate" and "report" in result:
+                ran[-1]["report"] = result["report"]
+        return jsonify({
+            "ok": True,
+            "segment": segment_id,
+            "from_step": step,
+            "planned": steps,
+            "ran": ran,
+        })
 
     # -- API: serve media files ------------------------------------------------
 

--- a/tests/test_asset_graph.py
+++ b/tests/test_asset_graph.py
@@ -1,0 +1,294 @@
+"""Tests for wizard asset freshness graph + rebuild-from-here cascade."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from docgen.asset_graph import (
+    cascade_steps,
+    segment_asset_report,
+    segment_step_statuses,
+)
+from docgen.config import Config
+from docgen.wizard import create_app, generate_narration_via_llm
+
+
+def test_cascade_steps_default_uses_retime() -> None:
+    assert cascade_steps("tts") == [
+        "tts",
+        "timestamps",
+        "scene-retime",
+        "manim",
+        "compose",
+        "validate",
+    ]
+    assert cascade_steps("scene-retime")[0] == "scene-retime"
+    assert "scene-spec" not in cascade_steps("timestamps")
+
+
+def test_cascade_steps_scene_spec_tail() -> None:
+    assert cascade_steps("scene-spec") == [
+        "scene-spec",
+        "manim",
+        "compose",
+        "validate",
+    ]
+
+
+def test_cascade_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="unknown"):
+        cascade_steps("nope")
+
+
+def _bundle(tmp_path: Path) -> Config:
+    raw = {
+        "segments": {"all": ["01"], "default": ["01"]},
+        "segment_names": {"01": "01-demo"},
+        "visual_map": {
+            "01": {"type": "manim", "scene": "DemoScene", "source": "DemoScene.mp4"}
+        },
+        "dirs": {
+            "narration": "narration",
+            "audio": "audio",
+            "animations": "animations",
+            "recordings": "recordings",
+        },
+    }
+    (tmp_path / "docgen.yaml").write_text(yaml.dump(raw), encoding="utf-8")
+    for d in ("narration", "audio", "animations", "recordings", "animations/specs"):
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
+    return Config.from_yaml(tmp_path / "docgen.yaml")
+
+
+def test_segment_statuses_missing_then_fresh(tmp_path: Path) -> None:
+    cfg = _bundle(tmp_path)
+    statuses = {s.step: s for s in segment_step_statuses(cfg, "01")}
+    assert statuses["tts"].status == "missing"
+    assert statuses["timestamps"].status == "missing"
+
+    narr = cfg.narration_dir / "01-demo.md"
+    narr.write_text("Hello world.\n", encoding="utf-8")
+    time.sleep(0.02)
+    audio = cfg.audio_dir / "01-demo.mp3"
+    audio.write_bytes(b"fake")
+    time.sleep(0.02)
+    (cfg.animations_dir / "timing.json").write_text(
+        json.dumps({"01-demo": {"words": [{"word": "Hello", "start": 0, "end": 0.2}]}}),
+        encoding="utf-8",
+    )
+    time.sleep(0.02)
+    spec = cfg.animations_dir / "specs" / "01-demo.scene.yaml"
+    spec.write_text("segment_id: '01'\n", encoding="utf-8")
+    time.sleep(0.02)
+    visual = cfg.animations_dir / "DemoScene.mp4"
+    visual.write_bytes(b"vid")
+    time.sleep(0.02)
+    rec = cfg.recordings_dir / "01-demo.mp4"
+    rec.write_bytes(b"rec")
+
+    statuses = {s.step: s for s in segment_step_statuses(cfg, "01")}
+    assert statuses["tts"].status == "fresh"
+    assert statuses["timestamps"].status == "fresh"
+    assert statuses["scene-retime"].status == "fresh"
+    assert statuses["manim"].status == "fresh"
+    assert statuses["compose"].status == "fresh"
+
+
+def test_stale_when_narration_newer_than_audio(tmp_path: Path) -> None:
+    cfg = _bundle(tmp_path)
+    audio = cfg.audio_dir / "01-demo.mp3"
+    audio.write_bytes(b"old")
+    narr = cfg.narration_dir / "01-demo.md"
+    narr.write_text("newer narration\n", encoding="utf-8")
+    # Force a clear mtime gap beyond the 1s freshness tolerance.
+    now = time.time()
+    import os
+
+    os.utime(audio, (now - 10, now - 10))
+    os.utime(narr, (now, now))
+    statuses = {s.step: s for s in segment_step_statuses(cfg, "01")}
+    assert statuses["tts"].status == "stale"
+
+
+def test_api_segments_includes_assets(tmp_path: Path) -> None:
+    cfg = _bundle(tmp_path)
+    (cfg.narration_dir / "01-demo.md").write_text("hi\n", encoding="utf-8")
+    app = create_app(cfg)
+    client = app.test_client()
+    res = client.get("/api/segments")
+    assert res.status_code == 200
+    seg = res.get_json()["segments"][0]
+    assert "assets" in seg
+    steps = {s["step"] for s in seg["assets"]["steps"]}
+    assert "tts" in steps
+    assert "scene-retime" in steps
+
+    assets = client.get("/api/segments/01/assets")
+    assert assets.status_code == 200
+    assert assets.get_json()["segment_id"] == "01"
+
+
+def test_api_run_from_cascades_mocked(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _bundle(tmp_path)
+    app = create_app(cfg)
+    client = app.test_client()
+    called: list[str] = []
+
+    from docgen import compose, manim_runner, scene_retime, timestamps, validate
+
+    monkeypatch.setattr(
+        timestamps.TimestampExtractor,
+        "resolve_engine",
+        lambda self, e: "local",
+    )
+    monkeypatch.setattr(
+        timestamps.TimestampExtractor,
+        "extract_local",
+        lambda self, mp3: called.append("timestamps")
+        or {"words": [{"word": "hi", "start": 0, "end": 0.1}]},
+    )
+    monkeypatch.setattr(
+        scene_retime,
+        "list_scene_spec_paths",
+        lambda cfg, segment_id=None: [
+            tmp_path / "animations" / "specs" / "01-demo.scene.yaml"
+        ],
+    )
+    monkeypatch.setattr(
+        scene_retime,
+        "retime_compile_spec",
+        lambda cfg, path, dry_run=False: called.append("scene-retime")
+        or {"path": path, "wrote": True},
+    )
+    monkeypatch.setattr(
+        manim_runner.ManimRunner,
+        "render",
+        lambda self, scene=None: called.append("manim") or None,
+    )
+    monkeypatch.setattr(
+        compose.Composer,
+        "compose_segments",
+        lambda self, ids: called.append("compose") or True,
+    )
+    monkeypatch.setattr(
+        validate.Validator,
+        "validate_segment",
+        lambda self, sid: called.append("validate") or {"segment": sid, "checks": []},
+    )
+    monkeypatch.setattr(
+        "docgen.manim_scene_support.sync_audio_tail_waits_in_scenes",
+        lambda cfg: None,
+    )
+
+    (cfg.audio_dir / "01-demo.mp3").write_bytes(b"x")
+    (cfg.animations_dir / "specs" / "01-demo.scene.yaml").write_text("x", encoding="utf-8")
+
+    res = client.post("/api/run-from/timestamps/01", json={})
+    assert res.status_code == 200, res.get_json()
+    body = res.get_json()
+    assert body["ok"] is True
+    assert body["planned"][0] == "timestamps"
+    assert "scene-retime" in body["planned"]
+    assert "scene-spec" not in body["planned"]
+    assert called == ["timestamps", "scene-retime", "manim", "compose", "validate"]
+
+
+def test_revise_mode_includes_current_narration(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    class _FakeMsg:
+        content = "Revised script."
+
+    class _FakeChoice:
+        message = _FakeMsg()
+
+    class _FakeResp:
+        choices = [_FakeChoice()]
+
+    class _FakeCompletions:
+        def create(self, **kwargs):  # noqa: ANN003
+            captured.update(kwargs)
+            return _FakeResp()
+
+    class _FakeChat:
+        completions = _FakeCompletions()
+
+    class _FakeClient:
+        chat = _FakeChat()
+
+    monkeypatch.setattr("openai.OpenAI", lambda: _FakeClient())
+
+    out = generate_narration_via_llm(
+        source_texts=["## File: a.md\nsource"],
+        guidance="keep short",
+        system_prompt="Write narration.",
+        model="gpt-4o",
+        segment_name="01-demo",
+        revision_notes="Mention Flask",
+        current_narration="Original line about pipelines.",
+        mode="revise",
+    )
+    assert out == "Revised script."
+    user = captured["messages"][1]["content"]
+    assert "CURRENT NARRATION" in user
+    assert "Original line about pipelines." in user
+    assert "Mention Flask" in user
+    assert "revising an existing" in captured["messages"][0]["content"].lower()
+
+
+def test_revise_mode_requires_notes() -> None:
+    with pytest.raises(ValueError, match="revision_notes"):
+        generate_narration_via_llm(
+            source_texts=[],
+            guidance="",
+            system_prompt="x",
+            model="gpt-4o",
+            segment_name="01",
+            revision_notes="",
+            current_narration="Hello",
+            mode="revise",
+        )
+
+
+def test_api_generate_revise_writes_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _bundle(tmp_path)
+    (cfg.narration_dir / "01-demo.md").write_text("Old text.\n", encoding="utf-8")
+    app = create_app(cfg)
+    client = app.test_client()
+
+    monkeypatch.setattr(
+        "docgen.wizard.generate_narration_via_llm",
+        lambda **kwargs: "New revised text.",
+    )
+    res = client.post(
+        "/api/generate-narration",
+        json={
+            "segment_id": "01",
+            "segment_name": "01-demo",
+            "mode": "revise",
+            "current_narration": "Old text.",
+            "revision_notes": "Tighten the opening.",
+            "source_paths": [],
+        },
+    )
+    assert res.status_code == 200, res.get_json()
+    body = res.get_json()
+    assert body["mode"] == "revise"
+    assert "New revised text." in body["narration"]
+    assert (cfg.narration_dir / "01-demo.md").read_text(encoding="utf-8").startswith(
+        "New revised text."
+    )
+
+
+def test_segment_asset_report_lists_stale(tmp_path: Path) -> None:
+    cfg = _bundle(tmp_path)
+    report = segment_asset_report(cfg, "01")
+    assert "tts" in report["stale_or_missing"]
+    assert report["default_cascade"][2] == "scene-retime"

--- a/tests/test_scene_spec.py
+++ b/tests/test_scene_spec.py
@@ -960,9 +960,60 @@ def test_compile_edges_emits_arrows_and_grow() -> None:
         "edges": [{"from": "Hints", "to": "YAML", "color": "C_ACCENT"}],
     }
     out = compile_scene_class(spec)
-    assert "_ar_0_0 = _arrow(_bx_0_0_0.get_center(), _bx_0_0_1.get_center(), C_ACCENT)" in out
+    assert (
+        "_ar_0_0 = _arrow(_bx_0_0_0.get_center(), _bx_0_0_1.get_center(), "
+        "C_ACCENT, style='solid')"
+    ) in out
     assert "GrowArrow(_ar_0_0)" in out
     assert "FadeIn(_bx_0_0_1)" in out
+
+
+def test_compile_edges_dashed_label_uses_fadein() -> None:
+    spec = {
+        "segment_id": "01",
+        "class_name": "FlowScene",
+        "timing_key": "01-flow",
+        "title": {"text": "Flow", "font_size": 36, "color": "C_WHITE"},
+        "rows": [
+            {
+                "run_time": 0.8,
+                "boxes": [
+                    {
+                        "label": "A",
+                        "color": "C_GREEN",
+                        "width": 3.0,
+                        "height": 0.8,
+                        "font_size": 18,
+                        "wait_word": 0,
+                    },
+                    {
+                        "label": "B",
+                        "color": "C_BLUE",
+                        "width": 3.0,
+                        "height": 0.8,
+                        "font_size": 18,
+                        "wait_word": 1,
+                    },
+                ],
+            },
+        ],
+        "edges": [
+            {
+                "from": "A",
+                "to": "B",
+                "color": "C_ORANGE",
+                "style": "dashed",
+                "label": "optional",
+            }
+        ],
+    }
+    validate_scene_spec(spec)
+    out = compile_scene_class(spec)
+    assert "style='dashed'" in out
+    assert "_ar_0_0_lbl = Text('optional'" in out
+    assert "FadeIn(_ar_0_0)" in out
+    assert "FadeIn(_ar_0_0_lbl)" in out
+    assert "GrowArrow(_ar_0_0)" not in out
 
 
 def test_validate_edges_requires_known_labels() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the post-#56 checklist after [PR #60](https://github.com/jmjava/documentation-generator/pull/60) (story_end / av_sync anchors):

| # | Change |
|---|--------|
| 7 | **Wizard asset graph** — per-step freshness (`fresh` / `stale` / `missing`) via mtimes; **Rebuild from here** cascades through validate |
| 8 | **In-place narration revise** — `mode=revise` sends current editor text + revision notes (minimal edit); Regenerate stays a full rewrite |
| 10 | **Richer edges** — scene-spec `edges` gain optional `style: solid\|dashed` and short `label` captions |

### Wizard rebuild cascade (default)

```
tts → timestamps → scene-retime → manim → compose → validate
```

LLM `scene-spec` remains an explicit expensive step (select it in “Rebuild from” or use Regen scene spec).

### APIs

- `GET /api/segments` includes `assets` (also `GET /api/segments/<id>/assets`)
- `POST /api/run-from/<step>/<id>` — cascade runner
- `POST /api/run/scene-retime/<id>` — offline retime-compile
- `POST /api/generate-narration` accepts `mode`, `current_narration`

## Test plan

- [x] `pytest tests/` (311 passed)
- [x] `ruff check src/ tests/`
- [x] Unit: cascade order, stale TTS, run-from mocked cascade
- [x] Unit: revise prompt includes CURRENT NARRATION; API revise write
- [x] Unit: dashed/labeled edges FadeIn (not GrowArrow)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00237a80-25e6-45a1-b591-d369e4aeafb7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00237a80-25e6-45a1-b591-d369e4aeafb7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

